### PR TITLE
Fixed Boguscode for Text Attributes

### DIFF
--- a/MagickWand/drawing-wand.c
+++ b/MagickWand/drawing-wand.c
@@ -6038,7 +6038,7 @@ WandExport void DrawSetTextKerning(DrawingWand *wand,const double kerning)
   if (wand->debug != MagickFalse)
     (void) LogMagickEvent(WandEvent,GetMagickModule(),"%s",wand->name);
   if ((wand->filter_off != MagickFalse) &&
-      ((CurrentContext->kerning-kerning) >= MagickEpsilon))
+      (CurrentContext->kerning!=kerning))
     {
       CurrentContext->kerning=kerning;
       (void) MVGPrintf(wand,"kerning %lf\n",kerning);
@@ -6079,7 +6079,7 @@ WandExport void DrawSetTextInterlineSpacing(DrawingWand *wand,
   if (wand->debug != MagickFalse)
     (void) LogMagickEvent(WandEvent,GetMagickModule(),"%s",wand->name);
   if ((wand->filter_off != MagickFalse) &&
-      ((CurrentContext->interline_spacing-interline_spacing) >= MagickEpsilon))
+      (CurrentContext->interline_spacing!=interline_spacing))
     {
       CurrentContext->interline_spacing=interline_spacing;
       (void) MVGPrintf(wand,"interline-spacing %lf\n",interline_spacing);
@@ -6120,7 +6120,7 @@ WandExport void DrawSetTextInterwordSpacing(DrawingWand *wand,
   if (wand->debug != MagickFalse)
     (void) LogMagickEvent(WandEvent,GetMagickModule(),"%s",wand->name);
   if ((wand->filter_off != MagickFalse) &&
-      ((CurrentContext->interword_spacing-interword_spacing) >= MagickEpsilon))
+      (CurrentContext->interword_spacing!=interword_spacing))
     {
       CurrentContext->interword_spacing=interword_spacing;
       (void) MVGPrintf(wand,"interword-spacing %lf\n",interword_spacing);


### PR DESCRIPTION
Fixed DrawSetTextKerning, DrawSetTextInterlineSpacing,DrawSetTextInterwordSpacing that did not allow
the value to be changed, because of a faulty check against the previous value.